### PR TITLE
CakePHP 2.4 support

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-$options = array('engine' => 'EmailLogger.EmailLogger');
+$options = array('engine' => 'EmailLogger.Email');
 
 try {
 	Configure::load('EmailLogger.config');

--- a/Lib/Log/Engine/EmailLog.php
+++ b/Lib/Log/Engine/EmailLog.php
@@ -1,7 +1,7 @@
 <?php
 App::uses('CakeLogInterface', 'Log');
 App::uses('CakeEmail', 'Network/Email');
-class EmailLogger implements CakeLogInterface {
+class EmailLog implements CakeLogInterface {
 
 	public $config = array(
 		'levels' => array('warning', 'notice', 'debug', 'info', 'error'),

--- a/readme.textile
+++ b/readme.textile
@@ -1,6 +1,6 @@
 h1. EmailLogger plugin
 
-Email engine for CakeLog, CakePHP 2.x Sends out emails for log entries.
+Email engine for CakeLog, CakePHP >= 2.4.x Sends out emails for log entries.
 Optional configuration for log levels to send emails, by default to all core log levels.
 
 h2. Background
@@ -12,7 +12,7 @@ your app without turning debug on, or check errors that only occur with debug of
 h2. Requirements
 
 * PHP 5.3
-* CakePHP 2.x
+* CakePHP 2.4.x
 
 h2. Installation
 

--- a/readme.textile
+++ b/readme.textile
@@ -12,7 +12,7 @@ your app without turning debug on, or check errors that only occur with debug of
 h2. Requirements
 
 * PHP 5.3
-* CakePHP 2.4.x
+* CakePHP 2.4.x (CakePHP pre-2.4 checkout commit @eef768d7273dc9ffb50f6cc371e79d5de9e5e20c)
 
 h2. Installation
 


### PR DESCRIPTION
Probably not compatible with cake < 2.4

According to the cake 2.4 migration guide:

> Log engines do not need the suffix Log anymore in their setup configuration. So for the FileLog engine it suffices to define 'engine' => 'File' now. This unifies the way engines are named in configuration (see Cache engines for example). Note: If you have a Log engine like DatabaseLogger that does not follow the convention to use a suffix Log for your class name you have to adjust your class name to DatabaseLog. You should also avoid class names like SomeLogLog which include the suffix twice at the end.
